### PR TITLE
Update to 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.1.1
+
+### Added
+
+- added `getUserId()` and `getExternalUserId()` functions.
+
+### Fixed
+
+- fixed linux compilations issues with clang 18.X version
+- fixed progression event will now correctly send value
+
 ## 4.1.0
 
 ### Added

--- a/source/gameanalytics/GACommon.h
+++ b/source/gameanalytics/GACommon.h
@@ -85,7 +85,7 @@ namespace gameanalytics
         class GAState;
     }
 
-    constexpr const char* GA_VERSION_STR = "cpp 4.1.0";
+    constexpr const char* GA_VERSION_STR = "cpp 4.1.1";
 
     constexpr int MAX_CUSTOM_FIELDS_COUNT				 = 50;
     constexpr int MAX_CUSTOM_FIELDS_KEY_LENGTH			 = 64;


### PR DESCRIPTION
# Release Notes

### Added

- added `getUserId()` and `getExternalUserId()` functions.

### Fixed

- fixed linux compilations issues with clang 18.X version
- fixed progression event will now correctly send value
