### PR TITLE
Bump version to 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.4.0
 
 ### Added
 

--- a/source/gameanalytics/GACommon.h
+++ b/source/gameanalytics/GACommon.h
@@ -85,7 +85,7 @@ namespace gameanalytics
         class GAState;
     }
 
-    constexpr const char* GA_VERSION_STR = "cpp 5.3.1";
+    constexpr const char* GA_VERSION_STR = "cpp 5.4.0";
 
     constexpr int MAX_CUSTOM_FIELDS_COUNT				 = 50;
     constexpr int MAX_CUSTOM_FIELDS_KEY_LENGTH			 = 64;


### PR DESCRIPTION
Version bump ahead of the `v5.4.0` release.

- `GA_VERSION_STR` → `cpp 5.4.0` (`source/gameanalytics/GACommon.h`)
- `CHANGELOG.md`: `## Unreleased` → `## 5.4.0`

Contents of this release (already on `main`, #47 / #48 / #49): remote configs listener in the C API, Linux build compatibility fixes, Windows static builds moving to the dynamic MSVC runtime (`/MD`), and Unreal workflow fixes.

Minor rather than patch because #48 adds a new public C API function and the `/MD` switch is link-breaking for consumers still on `/MT`.

Once merged, the release is cut with `python gh_create_release.py v5.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)